### PR TITLE
patched out EnBal_UnlockSelectedAreaMap

### DIFF
--- a/src/tingle_hooks.c
+++ b/src/tingle_hooks.c
@@ -249,49 +249,6 @@ RECOMP_PATCH s32 EnBal_CheckIfMapUnlocked(EnBal* this, PlayState* play) {
     return rando_location_is_checked(this->purchaseMapId + 0xB4);
 }
 
-RECOMP_PATCH void EnBal_TryPurchaseMap(EnBal* this, PlayState* play) {
-    Player* player = GET_PLAYER(play);
-    s32 price;
-
-    if (Message_ShouldAdvance(play)) {
-        if (play->msgCtx.choiceIndex != TINGLE_MAPCHOICE_CANCEL) {
-            // Get price depending on which map player wants to buy
-            if (play->msgCtx.choiceIndex == TINGLE_MAPCHOICE_PROXIMAL) {
-                price = play->msgCtx.unk1206C;
-            } else {
-                price = play->msgCtx.unk12070;
-            }
-
-            if (gSaveContext.save.saveInfo.playerData.rupees < price) {
-                // Can't buy map because player doesn't have the money
-                Audio_PlaySfx(NA_SE_SY_ERROR);
-                Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, TINGLE_ANIM_TALK);
-                Message_StartTextbox(play, 0x1D0A, &this->picto.actor);
-                this->textId = 0x1D0A;
-            } else if (EnBal_CheckIfMapUnlocked(this, play)) {
-                // Can't buy map because player already has it
-                Audio_PlaySfx(NA_SE_SY_ERROR);
-                Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, TINGLE_ANIM_TALK);
-                Message_StartTextbox(play, 0x1D09, &this->picto.actor);
-                this->textId = 0x1D09;
-            } else {
-                // Proceed with map purchase
-                Audio_PlaySfx_MessageDecide();
-                Rupees_ChangeBy(-price);
-                Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, TINGLE_ANIM_MAGIC_REVERSE);
-                this->forceEyesShut = true;
-                Message_StartTextbox(play, 0x1D0B, &this->picto.actor);
-                this->textId = 0x1D0B;
-                // EnBal_UnlockSelectedAreaMap(this);
-                player->stateFlags1 |= PLAYER_STATE1_20;
-                EnBal_SetupOfferGetItem(this);
-            }
-        } else {
-            // Cancel
-            Audio_PlaySfx_MessageCancel();
-            Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, TINGLE_ANIM_TALK);
-            Message_StartTextbox(play, 0x1D06, &this->picto.actor);
-            this->textId = 0x1D06;
-        }
-    }
+RECOMP_PATCH void EnBal_UnlockSelectedAreaMap(EnBal* this) {
+    return;
 }


### PR DESCRIPTION
Replaced the patch to `EnBal_TryPurchaseMap`, which only serves to comment out the sole call to `EnBal_UnlockSelectedAreaMap`, with a patch simply removing the content of `EnBal_UnlockSelectedAreaMap`.